### PR TITLE
Ignore SSL certificate to test against encrypted ports

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func DoS(target string, proto string) {
 	if proto == "https" {
 		conf := &tls.Config{
 			ServerName: strings.Split(target, ":")[0],
+			InsecureSkipVerify: true,
 		}
 		conn = tls.Client(conn, conf)
 	}


### PR DESCRIPTION
Ignore ssl certificate to be able to scan against test environments with self signed certificate (also fixing the problem with not being able to scan against encrypted proto)